### PR TITLE
Depth cpuct scaling

### DIFF
--- a/engine/src/search_engine/engine_options.rs
+++ b/engine/src/search_engine/engine_options.rs
@@ -23,14 +23,13 @@ create_options! {
             common_pst: f64  =>  1.00,  0.1,  10.0,  0.1,  0.002;
 
             //Node Selection
-            root_cpuct:            f64  =>  1.15,     0.1,    5.0,      0.115,  0.002;
             cpuct:                 f64  =>  1.15,     0.1,    5.0,      0.075,  0.002;
             cpuct_visit_scale:     f64  =>  8000.00,  128.0,  65536.0,  800.0,  0.002;
             cpuct_variance_scale:  f64  =>  0.2,      0.1,    50.0,     0.02,   0.002;
             cpuct_variance_weight: f64  =>  0.85,     0.0,    2.0,      0.085,  0.002;
-            cpuct_depth_log:       f64  =>  2.71828,  1.0,    5.0,      0.272,  0.002;
-            cpuct_depth_scale:     f64  =>  6.80,     1.0,    10.0,     0.680,  0.002;
-            cpuct_min_depth_mul:   f64  =>  0.35,     0.0,    1.0,      0.035,  0.002;
+            cpuct_depth_log:       f64  =>  2.1523,   1.0,    5.0,      0.215,  0.002;
+            cpuct_depth_scale:     f64  =>  6.2415,   1.0,    10.0,     0.624,  0.002;
+            cpuct_min_depth_mul:   f64  =>  0.3517,   0.0,    1.0,      0.035,  0.002;
 
             //Transposition Table
             hash_size: f64  =>  0.04,  0.01,  0.5,  0.004,  0.002;

--- a/engine/src/search_engine/engine_options.rs
+++ b/engine/src/search_engine/engine_options.rs
@@ -24,10 +24,13 @@ create_options! {
 
             //Node Selection
             root_cpuct:            f64  =>  1.15,     0.1,    5.0,      0.115,  0.002;
-            cpuct:                 f64  =>  0.75,     0.1,    5.0,      0.075,  0.002;
+            cpuct:                 f64  =>  1.15,     0.1,    5.0,      0.075,  0.002;
             cpuct_visit_scale:     f64  =>  8000.00,  128.0,  65536.0,  800.0,  0.002;
-            cpuct_variance_scale:  f64  =>  0.2,      0.1,    50.0,     0.02,    0.002;
-            cpuct_variance_weight: f64  =>  0.85,      0.0,    2.0,     0.085,   0.002;
+            cpuct_variance_scale:  f64  =>  0.2,      0.1,    50.0,     0.02,   0.002;
+            cpuct_variance_weight: f64  =>  0.85,     0.0,    2.0,      0.085,  0.002;
+            cpuct_depth_log:       f64  =>  2.71828,  1.0,    5.0,      0.272,  0.002;
+            cpuct_depth_scale:     f64  =>  6.80,     1.0,    10.0,     0.680,  0.002;
+            cpuct_min_depth_mul:   f64  =>  0.35,     0.0,    1.0,      0.035,  0.002;
 
             //Transposition Table
             hash_size: f64  =>  0.04,  0.01,  0.5,  0.004,  0.002;


### PR DESCRIPTION
Elo   | 15.03 +- 7.27 (95%)
SPRT  | N=10000 Threads=1 Hash=256MB
LLR   | 3.31 (-2.94, 2.94) [0.00, 5.00]
Games | N: 4094 W: 1472 L: 1295 D: 1327
Penta | [106, 385, 947, 444, 165]
https://jackalbench.pythonanywhere.com/test/71/