### PR TITLE
Exploration scaling

### DIFF
--- a/engine/src/search_engine/engine_options.rs
+++ b/engine/src/search_engine/engine_options.rs
@@ -32,6 +32,7 @@ create_options! {
             cpuct_variance_weight: f64  =>  0.85,     0.0,    2.0,      0.085,  0.002;
             cpuct_depth_scale:     f64  =>  4.7845,   1.0,    10.0,     0.478,  0.002;
             cpuct_min_depth_mul:   f64  =>  0.3517,   0.0,    1.0,      0.035,  0.002;
+            exploration_scale:     f64  =>  0.55,     0.0,    1.0,      0.055,  0.002;
 
             //Transposition Table
             hash_size: f64  =>  0.04,  0.01,  0.5,  0.004,  0.002;

--- a/engine/src/search_engine/engine_options.rs
+++ b/engine/src/search_engine/engine_options.rs
@@ -32,7 +32,7 @@ create_options! {
             cpuct_variance_weight: f64  =>  0.85,     0.0,    2.0,      0.085,  0.002;
             cpuct_depth_scale:     f64  =>  4.7845,   1.0,    10.0,     0.478,  0.002;
             cpuct_min_depth_mul:   f64  =>  0.3517,   0.0,    1.0,      0.035,  0.002;
-            exploration_scale:     f64  =>  0.49,     0.0,    1.0,      0.055,  0.002;
+            exploration_scale:     f64  =>  0.47,     0.0,    1.0,      0.055,  0.002;
 
             //Transposition Table
             hash_size: f64  =>  0.04,  0.01,  0.5,  0.004,  0.002;

--- a/engine/src/search_engine/engine_options.rs
+++ b/engine/src/search_engine/engine_options.rs
@@ -32,7 +32,7 @@ create_options! {
             cpuct_variance_weight: f64  =>  0.85,     0.0,    2.0,      0.085,  0.002;
             cpuct_depth_scale:     f64  =>  4.7845,   1.0,    10.0,     0.478,  0.002;
             cpuct_min_depth_mul:   f64  =>  0.3517,   0.0,    1.0,      0.035,  0.002;
-            exploration_scale:     f64  =>  0.51,     0.0,    1.0,      0.055,  0.002;
+            exploration_scale:     f64  =>  0.53,     0.0,    1.0,      0.055,  0.002;
 
             //Transposition Table
             hash_size: f64  =>  0.04,  0.01,  0.5,  0.004,  0.002;

--- a/engine/src/search_engine/engine_options.rs
+++ b/engine/src/search_engine/engine_options.rs
@@ -32,7 +32,7 @@ create_options! {
             cpuct_variance_weight: f64  =>  0.85,     0.0,    2.0,      0.085,  0.002;
             cpuct_depth_scale:     f64  =>  4.7845,   1.0,    10.0,     0.478,  0.002;
             cpuct_min_depth_mul:   f64  =>  0.3517,   0.0,    1.0,      0.035,  0.002;
-            exploration_scale:     f64  =>  0.47,     0.0,    1.0,      0.055,  0.002;
+            exploration_scale:     f64  =>  0.51,     0.0,    1.0,      0.055,  0.002;
 
             //Transposition Table
             hash_size: f64  =>  0.04,  0.01,  0.5,  0.004,  0.002;

--- a/engine/src/search_engine/engine_options.rs
+++ b/engine/src/search_engine/engine_options.rs
@@ -32,7 +32,7 @@ create_options! {
             cpuct_variance_weight: f64  =>  0.85,     0.0,    2.0,      0.085,  0.002;
             cpuct_depth_scale:     f64  =>  4.7845,   1.0,    10.0,     0.478,  0.002;
             cpuct_min_depth_mul:   f64  =>  0.3517,   0.0,    1.0,      0.035,  0.002;
-            exploration_scale:     f64  =>  0.45,     0.0,    1.0,      0.055,  0.002;
+            exploration_scale:     f64  =>  0.49,     0.0,    1.0,      0.055,  0.002;
 
             //Transposition Table
             hash_size: f64  =>  0.04,  0.01,  0.5,  0.004,  0.002;

--- a/engine/src/search_engine/engine_options.rs
+++ b/engine/src/search_engine/engine_options.rs
@@ -32,7 +32,7 @@ create_options! {
             cpuct_variance_weight: f64  =>  0.85,     0.0,    2.0,      0.085,  0.002;
             cpuct_depth_scale:     f64  =>  4.7845,   1.0,    10.0,     0.478,  0.002;
             cpuct_min_depth_mul:   f64  =>  0.3517,   0.0,    1.0,      0.035,  0.002;
-            exploration_scale:     f64  =>  0.53,     0.0,    1.0,      0.055,  0.002;
+            exploration_tau:       f64  =>  0.51,     0.0,    1.0,      0.055,  0.002;
 
             //Transposition Table
             hash_size: f64  =>  0.04,  0.01,  0.5,  0.004,  0.002;

--- a/engine/src/search_engine/engine_options.rs
+++ b/engine/src/search_engine/engine_options.rs
@@ -32,7 +32,7 @@ create_options! {
             cpuct_variance_weight: f64  =>  0.85,     0.0,    2.0,      0.085,  0.002;
             cpuct_depth_scale:     f64  =>  4.7845,   1.0,    10.0,     0.478,  0.002;
             cpuct_min_depth_mul:   f64  =>  0.3517,   0.0,    1.0,      0.035,  0.002;
-            exploration_scale:     f64  =>  0.55,     0.0,    1.0,      0.055,  0.002;
+            exploration_scale:     f64  =>  0.45,     0.0,    1.0,      0.055,  0.002;
 
             //Transposition Table
             hash_size: f64  =>  0.04,  0.01,  0.5,  0.004,  0.002;

--- a/engine/src/search_engine/mcts.rs
+++ b/engine/src/search_engine/mcts.rs
@@ -73,7 +73,7 @@ impl SearchEngine {
         let mut depth = 0;
         let mut position = *self.current_position();
 
-        if !self.perform_iteration(&mut position, &mut depth, castle_mask) {
+        if !self.perform_iteration(&mut position, &mut depth, castle_mask, search_stats.avg_depth() as usize) {
             if search_limits.is_inifinite() {
                 while !self.is_search_interrupted() {}
             } else {

--- a/engine/src/search_engine/mcts/iteration.rs
+++ b/engine/src/search_engine/mcts/iteration.rs
@@ -12,8 +12,9 @@ impl SearchEngine {
         position: &mut ChessPosition,
         depth: &mut u64,
         castle_mask: &[u8; 64],
+        avg_depth: usize,
     ) -> bool { 
-        let mut selection_stack: Vec<(usize, ZobristKey)> = Vec::new();
+        let mut selection_stack: Vec<(usize, ZobristKey)> = Vec::with_capacity(avg_depth);
 
         let selected_node = self.select_and_expand(position, &mut selection_stack, castle_mask);
 

--- a/engine/src/search_engine/mcts/iteration/select_expand.rs
+++ b/engine/src/search_engine/mcts/iteration/select_expand.rs
@@ -16,7 +16,7 @@ impl SearchEngine {
 
             node_idx = self.tree().select_child_by_key(node_idx, |child_node| {
                 let score = get_score(&parent_node.score(), child_node, child_node.visits()).single(0.5) as f64;
-                let exploration_factor = f64::from(parent_node.visits().max(1)).sqrt() / f64::from(child_node.visits() + 1);
+                let exploration_factor = get_exploration_scale(self.options(), &parent_node) / f64::from(child_node.visits() + 1);
                 score + cpuct * child_node.policy() * exploration_factor
             }).expect("Failed to select a valid node.");
 
@@ -76,4 +76,8 @@ fn get_cpuct(options: &EngineOptions, parent_node: &Node, depth: f64) -> f64 {
     cpuct *= (1.0 - depth.ln() / options.cpuct_depth_scale()).max(options.cpuct_min_depth_mul());
 
     cpuct
+}
+
+fn get_exploration_scale(options: &EngineOptions, parent_node: &Node) -> f64 {
+    (options.exploration_scale() * f64::from(parent_node.visits().max(1)).ln()).exp()
 }

--- a/engine/src/search_engine/mcts/iteration/select_expand.rs
+++ b/engine/src/search_engine/mcts/iteration/select_expand.rs
@@ -13,11 +13,13 @@ impl SearchEngine {
             let depth = selection_stack.len() as f64;
 
             let cpuct = get_cpuct(&self.options(), &parent_node, depth);
+            let exploration_scale = get_exploration_scale(self.options(), &parent_node);
+
+            let expl = cpuct * exploration_scale;
 
             node_idx = self.tree().select_child_by_key(node_idx, |child_node| {
                 let score = get_score(&parent_node.score(), child_node, child_node.visits()).single(0.5) as f64;
-                let exploration_factor = get_exploration_scale(self.options(), &parent_node) / f64::from(child_node.visits() + 1);
-                score + cpuct * child_node.policy() * exploration_factor
+                score + child_node.policy() * expl / f64::from(child_node.visits() + 1)
             }).expect("Failed to select a valid node.");
 
             position.make_move(self.tree().get_node(node_idx).mv(), castle_mask);
@@ -79,5 +81,5 @@ fn get_cpuct(options: &EngineOptions, parent_node: &Node, depth: f64) -> f64 {
 }
 
 fn get_exploration_scale(options: &EngineOptions, parent_node: &Node) -> f64 {
-    (options.exploration_scale() * f64::from(parent_node.visits().max(1)).ln()).exp()
+    (options.exploration_tau() * (parent_node.visits().max(1) as f64).ln()).exp()
 }


### PR DESCRIPTION
Elo   | 7.02 +- 4.60 (95%)
SPRT  | 40.0+0.40s Threads=1 Hash=256MB
LLR   | 2.99 (-2.94, 2.94) [0.00, 5.00]
Games | N: 7768 W: 2275 L: 2118 D: 3375
Penta | [111, 825, 1883, 926, 139]
https://jackalbench.pythonanywhere.com/test/85/