### PR TITLE
Better mate backprop

### DIFF
--- a/engine/src/search_engine/mcts/iteration.rs
+++ b/engine/src/search_engine/mcts/iteration.rs
@@ -16,6 +16,9 @@ impl SearchEngine {
     ) -> Option<WDLScore> { 
         let hash = position.board().hash();
         let node = &self.tree()[node_idx];
+
+        let mut selected_child_idx = None;
+
         let score = if !ROOT && (node.is_terminal() || node.visits() == 0) {
             self.simulate(node_idx, position)
         } else {
@@ -28,6 +31,8 @@ impl SearchEngine {
             self.tree().update_node(node_idx)?;
 
             let new_idx = self.select(node_idx, *depth);
+
+            selected_child_idx = Some(new_idx);
 
             position.make_move(self.tree()[new_idx].mv(), castle_mask);
 
@@ -48,7 +53,7 @@ impl SearchEngine {
             score?
         }.reversed();
 
-        self.backpropagate(node_idx, score, hash);
+        self.backpropagate(node_idx, selected_child_idx, score, hash);
 
         Some(score)
     }

--- a/engine/src/search_engine/mcts/iteration/backpropagate.rs
+++ b/engine/src/search_engine/mcts/iteration/backpropagate.rs
@@ -3,35 +3,38 @@ use chess::ZobristKey;
 use crate::{search_engine::tree::{NodeIndex, Tree}, GameState, SearchEngine, WDLScore};
 
 impl SearchEngine {
-    pub(super) fn backpropagate(&self, node_idx: NodeIndex, score: WDLScore, key: ZobristKey) {
+    pub(super) fn backpropagate(&self, node_idx: NodeIndex, child_idx: Option<NodeIndex>, score: WDLScore, key: ZobristKey) {
         self.tree().add_visit(node_idx, score);
-        backprop_state(self.tree(), node_idx);
+        backprop_state(self.tree(), node_idx, child_idx);
         self.tree().hash_table().push(key, score.reversed());
     }
 }
 
-fn backprop_state(tree: &Tree, node_idx: NodeIndex) {
-    let mut proven_loss = true;
-    let mut proven_loss_length = 0;
+fn backprop_state(tree: &Tree, node_idx: NodeIndex, child_idx: Option<NodeIndex>) -> Option<()> {
+    let child_idx = child_idx?;
 
-    if tree[node_idx].children_count() == 0 {
-        return;
+    match tree[child_idx].state() {
+        GameState::Loss(len) => {
+            tree.set_state(node_idx, GameState::Win(len + 1));
+        },
+        GameState::Win(len) => {
+            let mut proven_loss = true;
+            let mut proven_loss_length = len;
+
+            tree[node_idx].map_children(|child_idx| {
+                if let GameState::Win(x) = tree[child_idx].state() {
+                    proven_loss_length = x.max(proven_loss_length);
+                } else {
+                    proven_loss = false;
+                }
+            });
+
+            if proven_loss {
+                tree.set_state(node_idx, GameState::Loss(proven_loss_length + 1));
+            }
+        },
+        _ => (),
     }
 
-    tree[node_idx].map_children(|child_idx| { //TODO: Flip this loop
-        match tree[child_idx].state() {
-            GameState::Loss(len) => {
-                tree.set_state(node_idx, GameState::Win(len + 1));
-                proven_loss = false;
-            },
-            GameState::Win(len) => {
-                proven_loss_length = proven_loss_length.max(len)
-            },
-            _ => proven_loss = false,
-        }
-    });
-
-    if proven_loss {
-        tree.set_state(node_idx, GameState::Loss(proven_loss_length + 1));
-    }
+    Some(())
 }


### PR DESCRIPTION
Elo   | 8.48 +- 5.32 (95%)
SPRT  | 10.0+0.10s Threads=1 Hash=32MB
LLR   | 2.97 (-2.94, 2.94) [0.00, 5.00]
Games | N: 6638 W: 1814 L: 1652 D: 3172
Penta | [127, 736, 1453, 854, 149]
https://jackalbench.pythonanywhere.com/test/193/