### PR TITLE
Variance warmup

### DIFF
--- a/engine/src/search_engine/engine_options.rs
+++ b/engine/src/search_engine/engine_options.rs
@@ -32,6 +32,7 @@ create_options! {
             cpuct_visit_scale:     f64  =>  8000.00,   128.0,  65536.0,  800.0,    0.002;
             cpuct_variance_scale:  f64  =>  0.2,       0.1,    50.0,     0.02,     0.002;
             cpuct_variance_weight: f64  =>  0.85,      0.0,    2.0,      0.085,    0.002;
+            cpuct_var_warmup:      f64  =>  0.5,       0.0,    1.0,      0.05,     0.002;
             exploration_tau:       f64  =>  0.51,      0.0,    1.0,      0.055,    0.002;
 
             //Time manager

--- a/engine/src/search_engine/mcts/iteration/select.rs
+++ b/engine/src/search_engine/mcts/iteration/select.rs
@@ -42,7 +42,8 @@ fn get_cpuct(options: &EngineOptions, parent_node: &Node, depth: f64) -> f64 {
 
     if parent_node.visits() > 1 {
         let var = (parent_node.squared_score() - (parent_node.score().single(0.5) as f64).powi(2)).max(0.0);
-        let variance = var.sqrt() / options.cpuct_variance_scale();
+        let mut variance = var.sqrt() / options.cpuct_variance_scale();
+        variance += (1.0 - variance) / (1.0 + options.cpuct_var_warmup() * parent_node.visits() as f64);
         cpuct *= 1.0 + options.cpuct_variance_weight() * (variance - 1.0);
     }
 


### PR DESCRIPTION
Elo   | 3.62 +- 2.79 (95%)
SPRT  | 10.0+0.10s Threads=1 Hash=32MB
LLR   | 3.18 (-2.94, 2.94) [0.00, 5.00]
Games | N: 24300 W: 6506 L: 6253 D: 11541
Penta | [487, 2845, 5283, 2998, 537]
https://jackalbench.pythonanywhere.com/test/194/