### PR TITLE
Half move scaling

### DIFF
--- a/engine/src/search_engine/engine_options.rs
+++ b/engine/src/search_engine/engine_options.rs
@@ -36,7 +36,11 @@ create_options! {
             cpuct_var_warmup:      f64  =>  0.5,       0.0,    1.0,      0.05,     0.002;
             exploration_tau:       f64  =>  0.51,      0.0,    1.0,      0.055,    0.002;
 
-            //Time manager
+            //Draw Scaling
+            draw_scaling_power: f64  =>  3.0,  1.0,  10.0,  0.3,   0.002;
+            draw_scaling_cap:   f64  =>  0.9,  0.0,  1.0,   0.08,  0.002;
+
+            //Time Manager
             default_moves_to_go:    f64  =>  30.0,         10.0,  50.0,  3.0,      0.002;
             phase_power:            f64  =>  2.0,          0.0,   10.0,  0.2,      0.002;
             phase_scale:            f64  =>  1.0,          0.0,   1.0,   0.1,      0.002;

--- a/engine/src/search_engine/mcts/iteration/simulate.rs
+++ b/engine/src/search_engine/mcts/iteration/simulate.rs
@@ -57,12 +57,14 @@ fn is_draw(position: &ChessPosition, root_position: &ChessPosition) -> bool {
 }
 
 fn get_position_score(position: &ChessPosition, node_state: GameState, contempt: &Contempt, options: &EngineOptions, is_stm: bool) -> WDLScore {
-    let score = match node_state {
+    let mut score = match node_state {
         GameState::Draw => WDLScore::DRAW,
         GameState::Loss(_) => WDLScore::LOSE,
         GameState::Win(_) => WDLScore::WIN,
         _ => ValueNetwork.forward(position.board())
     };
+
+    score.apply_50mr(position.board().half_moves(), options);
 
     let mut draw_chance= score.draw_chance();
     let mut win_lose_delta = score.win_chance() - score.lose_chance();

--- a/terminal/src/processors/misc_processor.rs
+++ b/terminal/src/processors/misc_processor.rs
@@ -210,8 +210,12 @@ fn eval(search_engine: &SearchEngine) {
     let contempt_score = WDLScore::new((1.0 + v - d) / 2.0, d);
     let contempt_eval = contempt_score.cp();
 
+    let mut half_moves = wdl_score;
+    half_moves.apply_50mr(board.half_moves(), search_engine.options());
+    let half_moves_cp = half_moves.cp();
+
     let mut info: [String; 33] = [const { String::new() }; 33];
-    info[1] = format!("Raw: {}", 
+    info[1] = format!("Raw:      {}", 
         format!("[{}, {}, {}] ({}{})",
             format!("{:.2}%", wdl_score.win_chance() * 100.0).custom_color(WIN_COLOR),
             format!("{:.2}%", wdl_score.draw_chance() * 100.0).custom_color(DRAW_COLOR),
@@ -229,6 +233,15 @@ fn eval(search_engine: &SearchEngine) {
             heat_color(format!("{:.2}", contempt_eval.abs() as f32 / 100.0).as_str(), contempt_eval as f32 / 100.0, -20.0, 20.0),
         ).secondary(2.0/32.0)
     ).primary(2.0/32.0);
+    info[3] = format!("50mr:     {}", 
+        format!("[{}, {}, {}] ({}{})",
+            format!("{:.2}%", half_moves.win_chance() * 100.0).custom_color(WIN_COLOR),
+            format!("{:.2}%", half_moves.draw_chance() * 100.0).custom_color(DRAW_COLOR),
+            format!("{:.2}%", half_moves.lose_chance() * 100.0).custom_color(LOSE_COLOR),
+            heat_color(if half_moves_cp > 0 { "+" } else { "-" }, half_moves_cp as f32 / 100.0, -20.0, 20.0),
+            heat_color(format!("{:.2}", half_moves_cp.abs() as f32 / 100.0).as_str(), half_moves_cp as f32 / 100.0, -20.0, 20.0),
+        ).secondary(3.0/32.0)
+    ).primary(3.0/32.0);
 
     let mut evals = [0; 64];
     board.occupancy().map(|square| {


### PR DESCRIPTION
Elo   | 11.87 +- 6.76 (95%)
SPRT  | 10.0+0.10s Threads=1 Hash=32MB
LLR   | 3.39 (-2.94, 2.94) [0.00, 5.00]
Games | N: 6882 W: 3352 L: 3117 D: 413
Penta | [490, 160, 2002, 203, 586]
https://jackalbench.pythonanywhere.com/test/223/